### PR TITLE
[ENH] Fix coiteration algorithm to handle nested levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,18 @@ CTEST_OUTPUT_ON_FAILURE=1 cmake --build build/test --target test
 ./build/test/GreeterTests
 ```
 
+To define a different compiler. For example if you are working on a Mac, with
+gcc-13 installed via Homewbrew, you might want to run this to switch compilers.
+This can happen when you want to test against different compilers, or if the Mac
+compiler is not up-to-date (e.g. there are known bugs that occur on Macs that are
+not fixed, but are fixed in open-source compilers).
 
+```bash
 cmake -DCMAKE_C_COMPILER=/opt/homebrew/bin/gcc-13 -DCMAKE_CXX_COMPILER=/opt/homebrew/bin/g++-13 -S test -B build/test
+
+cmake --build build/test
+CTEST_OUTPUT_ON_FAILURE=1 cmake --build build/test --target test
+```
 
 To enable debug mode
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ CTEST_OUTPUT_ON_FAILURE=1 cmake --build build/test --target test
 ./build/test/GreeterTests
 ```
 
+
+cmake -DCMAKE_C_COMPILER=/opt/homebrew/bin/gcc-13 -DCMAKE_CXX_COMPILER=/opt/homebrew/bin/g++-13 -S test -B build/test
+
 To enable debug mode
 
 ```bash

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -407,6 +407,13 @@ namespace xsparse::level_capabilities
         };
 
         coiteration_helper coiter_helper(std::tuple<Is...> i, std::tuple<Ps...> pkm1)
+        /**
+         * @brief 
+         * 
+         * IK can be a single min_ik if we are coiterating over the same coordinate each level
+         * 
+         * IK
+         */
         {
             return coiteration_helper{ *this, i, pkm1 };
         }

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -181,10 +181,6 @@ namespace xsparse::level_capabilities
                 : m_coiterate(coiterate)
                 , m_i(std::move(i))
                 , m_pkm1(std::move(pkm1))
-                // , m_iterHelpers(std::apply([&](auto&... args)
-                // {
-                //     return std::tuple(args.iter_helper(m_i, m_pkm1)...);
-                // }, coiterate.m_levelsTuple))
                 , m_iterHelpers(unfold_and_apply_helper(
                       coiterate.m_levelsTuple, m_i, pkm1, std::index_sequence_for<Ps...>{}))
             {

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -173,7 +173,7 @@ namespace xsparse::level_capabilities
                 , m_i(std::move(i))
                 , m_pkm1(std::move(pkm1))
                 , m_iterHelpers(std::apply(
-                      [&](auto&... args) { return std::make_tuple(args.iter_helper(i, pkm1)...); },
+                      [&](auto&... args) { return std::tuple(args.iter_helper(i, pkm1)...); },
                       coiterate.m_levelsTuple))
             {
             }

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -58,7 +58,13 @@ namespace xsparse::level_capabilities
      * @param levels - A tuple of levels is passed in during runtime via the constructor.
      */
 
-    template <template <bool...> class F, class Ffunc, class IK, class PK, class Levels, class Is, class Ps>
+    template <template <bool...> class F,
+              class Ffunc,
+              class IK,
+              class PK,
+              class Levels,
+              class Is,
+              class Ps>
     class Coiterate;
 
     // XXX: This double-passing of the function `F` and `Ffunc` is a workaround
@@ -166,11 +172,9 @@ namespace xsparse::level_capabilities
                 : m_coiterate(coiterate)
                 , m_i(std::move(i))
                 , m_pkm1(std::move(pkm1))
-                , m_iterHelpers(std::apply([&](auto&... args)
-                                           { return std::make_tuple(
-                                            args.iter_helper(std::get<decltype(args)::value_type>(i),
-                                                             std::get<decltype(args)::value_type>(pkm1))...); },
-                                           coiterate.m_levelsTuple))
+                , m_iterHelpers(std::apply(
+                      [&](auto&... args) { return std::make_tuple(args.iter_helper(i, pkm1)...); },
+                      coiterate.m_levelsTuple))
             {
             }
 
@@ -408,11 +412,14 @@ namespace xsparse::level_capabilities
 
         coiteration_helper coiter_helper(std::tuple<Is...> i, std::tuple<Ps...> pkm1)
         /**
-         * @brief 
-         * 
+         * @brief
+         *
          * IK can be a single min_ik if we are coiterating over the same coordinate each level
-         * 
-         * IK
+         *
+         * IK is a tuple where each element corresponds to the depth of the level
+         *
+         * PKM1 is a tuple where each element corresponds to a level/array that we would iterate
+         * over in the current depth.
          */
         {
             return coiteration_helper{ *this, i, pkm1 };

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -181,24 +181,21 @@ namespace xsparse::level_capabilities
                 : m_coiterate(coiterate)
                 , m_i(std::move(i))
                 , m_pkm1(std::move(pkm1))
-                , m_iterHelpers(std::apply([&](auto&... args)
-                               {
-                                   return std::tuple(
-                                       (std::tuple_size<decltype(m_i)>::value > 0) ?
-                                       args.iter_helper(std::get<0>(m_i), m_pkm1) :
-                                       args.iter_helper(m_i, m_pkm1))...);
-                               },
-                               coiterate.m_levelsTuple))
                 // , m_iterHelpers(std::apply([&](auto&... args)
-                //                            { return std::tuple(args.iter_helper(std::get<0>(m_i), pkm1)...); },
-                //                            coiterate.m_levelsTuple))
-                // , m_iterHelpers(unfold_and_apply_helper(
-                //       coiterate.m_levelsTuple, i, pkm1, std::index_sequence_for<Ps...>{}))
+                // {
+                //     return std::tuple(args.iter_helper(std::get<0>(m_i), m_pkm1)...);
+                // }, coiterate.m_levelsTuple))
+                , m_iterHelpers(unfold_and_apply_helper(coiterate.m_levelsTuple,
+                                                        std::get<0>(m_i),
+                                                        pkm1,
+                                                        std::index_sequence_for<Ps...>{}))
             {
+                // PKM1 should have the same number of elements as the number of levels in
+                // `m_levelsTuple`
+                static_assert(
+                    std::tuple_size_v<std::remove_reference_t<decltype(coiterate.m_levelsTuple)>>
+                    == std::tuple_size_v<std::remove_reference_t<decltype(pkm1)>>);
             }
-                // TODO: try to write a custom template to only unfold the PKM1s. The i can prolly
-                // be left as is.
-                // maybe try std::apply within the std::tuple to unfold the pkm1
 
             class iterator
             {

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -176,8 +176,8 @@ namespace xsparse::level_capabilities
 
         public:
             explicit inline coiteration_helper(Coiterate const& coiterate,
-                                               std::tuple<Is...> i,
-                                               std::tuple<Ps...> pkm1) noexcept
+                                               std::tuple<Is...> const i,
+                                               std::tuple<Ps...> const pkm1) noexcept
                 : m_coiterate(coiterate)
                 , m_i(std::move(i))
                 , m_pkm1(std::move(pkm1))
@@ -185,10 +185,8 @@ namespace xsparse::level_capabilities
                 // {
                 //     return std::tuple(args.iter_helper(m_i, m_pkm1)...);
                 // }, coiterate.m_levelsTuple))
-                , m_iterHelpers(unfold_and_apply_helper(coiterate.m_levelsTuple,
-                                                        m_i,
-                                                        pkm1,
-                                                        std::index_sequence_for<Ps...>{}))
+                , m_iterHelpers(unfold_and_apply_helper(
+                      coiterate.m_levelsTuple, m_i, pkm1, std::index_sequence_for<Ps...>{}))
             {
                 // PKM1 should have the same number of elements as the number of levels in
                 // `m_levelsTuple`
@@ -278,6 +276,15 @@ namespace xsparse::level_capabilities
                     calc_min_ik(std::make_index_sequence<std::tuple_size_v<decltype(iterators)>>{});
                 }
 
+                template <class iter>
+                inline auto deref_PKs(iter i) const noexcept
+                {
+                    return std::get<0>(*i) == min_ik
+                               ? std::optional<std::tuple_element_t<1, decltype(*i)>>(
+                                   std::get<1>(*i))
+                               : std::nullopt;
+                }
+
                 template <class iter, std::size_t I>
                 inline constexpr auto get_PK_iter(iter& i) const noexcept
                 /**
@@ -341,15 +348,6 @@ namespace xsparse::level_capabilities
                 {
                     return get_PKs_complete(
                         std::make_index_sequence<std::tuple_size_v<decltype(iterators)>>{});
-                }
-
-                template <class iter>
-                inline auto deref_PKs(iter i) const noexcept
-                {
-                    return (std::get<0>(*i) == min_ik)
-                               ? std::optional<std::tuple_element_t<1, decltype(*i)>>(
-                                   std::get<1>(*i))
-                               : std::nullopt;
                 }
 
                 template <class iter>
@@ -429,7 +427,7 @@ namespace xsparse::level_capabilities
             }
         };
 
-        coiteration_helper coiter_helper(std::tuple<Is...> i, std::tuple<Ps...> pkm1)
+        coiteration_helper coiter_helper(std::tuple<Is...> const i, std::tuple<Ps...> const pkm1)
         /**
          * @brief Initialize the co-iterator helper object.
          *

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -183,10 +183,10 @@ namespace xsparse::level_capabilities
                 , m_pkm1(std::move(pkm1))
                 // , m_iterHelpers(std::apply([&](auto&... args)
                 // {
-                //     return std::tuple(args.iter_helper(std::get<0>(m_i), m_pkm1)...);
+                //     return std::tuple(args.iter_helper(m_i, m_pkm1)...);
                 // }, coiterate.m_levelsTuple))
                 , m_iterHelpers(unfold_and_apply_helper(coiterate.m_levelsTuple,
-                                                        std::get<0>(m_i),
+                                                        m_i,
                                                         pkm1,
                                                         std::index_sequence_for<Ps...>{}))
             {

--- a/include/xsparse/level_capabilities/coordinate_iterate.hpp
+++ b/include/xsparse/level_capabilities/coordinate_iterate.hpp
@@ -142,7 +142,8 @@ namespace xsparse::level_capabilities
             }
         };
 
-        iteration_helper iter_helper(typename BaseTraits::I i, typename BaseTraits::PKM1 pkm1)
+        iteration_helper iter_helper(typename BaseTraits::I const i,
+                                     typename BaseTraits::PKM1 const pkm1)
         {
             return iteration_helper{ *static_cast<typename BaseTraits::Level*>(this), i, pkm1 };
         }
@@ -268,7 +269,8 @@ namespace xsparse::level_capabilities
             }
         };
 
-        iteration_helper iter_helper(typename BaseTraits::I i, typename BaseTraits::PKM1 pkm1)
+        iteration_helper iter_helper(typename BaseTraits::I const i,
+                                     typename BaseTraits::PKM1 const pkm1)
         {
             return iteration_helper{ *static_cast<typename BaseTraits::Level*>(this), i, pkm1 };
         }

--- a/include/xsparse/levels/compressed.hpp
+++ b/include/xsparse/levels/compressed.hpp
@@ -80,7 +80,7 @@ namespace xsparse
             {
             }
 
-            inline std::pair<PK, PK> pos_bounds(typename BaseTraits::PKM1 pkm1) const noexcept
+            inline std::pair<PK, PK> pos_bounds(typename BaseTraits::PKM1 const pkm1) const noexcept
             {
                 return { m_pos[pkm1], m_pos[static_cast<typename BaseTraits::PKM1>(pkm1 + 1)] };
             }
@@ -95,7 +95,7 @@ namespace xsparse
                 m_pos.resize(szkm1 + 1);
             }
 
-            inline void append_edges(typename BaseTraits::PKM1 pkm1,
+            inline void append_edges(typename BaseTraits::PKM1 const pkm1,
                                      typename BaseTraits::PK pk_begin,
                                      typename BaseTraits::PK pk_end) noexcept
             {

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Coiteration-Dense-Dense")
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2)>,
         std::tuple<>,
-        std::tuple<>>
+        std::tuple<uintptr_t, uintptr_t>>
         coiter(fn, s1, s2);
 
     auto it_helper1 = s1.iter_helper(std::make_tuple(), ZERO);
@@ -48,7 +48,8 @@ TEST_CASE("Coiteration-Dense-Dense")
     auto end1 = it_helper1.end();
     auto end2 = it_helper2.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO)))
+    for (auto const [ik, pk_tuple] :
+         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
     {
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
@@ -86,7 +87,7 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3)>,
         std::tuple<>,
-        std::tuple<>>
+        std::tuple<uintptr_t, uintptr_t, uintptr_t>>
         coiter(fn, s1, s2, s3);
 
     auto it_helper1 = s1.iter_helper(std::make_tuple(), ZERO);
@@ -100,7 +101,8 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
     auto end2 = it_helper2.end();
     auto end3 = it_helper3.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple()))
+    for (auto const [ik, pk_tuple] :
+         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO, ZERO)))
     {
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
@@ -149,7 +151,7 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3), decltype(s4)>,
         std::tuple<>,
-        std::tuple<>>
+        std::tuple<uintptr_t, uintptr_t, uintptr_t, uintptr_t>>
         coiter(fn, s1, s2, s3, s4);
 
     auto it_helper1 = s1.iter_helper(std::make_tuple(), ZERO);
@@ -166,7 +168,8 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
     auto end3 = it_helper3.end();
     auto end4 = it_helper4.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple()))
+    for (auto const [ik, pk_tuple] :
+         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO, ZERO, ZERO)))
     {
         if (it1 != end1 && it2 != end2 && it3 != end3 && it4 != end4)
         {
@@ -254,7 +257,7 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
         uintptr_t,
         std::tuple<decltype(dense_level), decltype(hash_level)>,
         std::tuple<>,
-        std::tuple<>>
+        std::tuple<uintptr_t, uintptr_t>>
         coiter(fn, dense_level, hash_level);
 
     // define iteration helper through dense and hashed level
@@ -266,7 +269,8 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
 
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple()))
+    for (auto const [ik, pk_tuple] :
+         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
     {
         // get the index and pointer from the levels involved in co-iteration
         auto [i1, p1] = *it1;
@@ -308,53 +312,60 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
 
 TEST_CASE("Coiteration-Nested-Levels")
 {
-    // consider two nested compressed levels, where we coiterate over the dense and compressed levels
+    // consider two nested compressed levels, where we coiterate over the dense and compressed
+    // levels
     constexpr uintptr_t SIZE1 = 3;
     constexpr uintptr_t SIZE2 = 100;
     constexpr uint8_t ZERO = 0;
+
+    // the first 3 x 100 CSR array
     std::vector<uintptr_t> const pos{ 0, 2, 5, 9 };
     std::vector<uintptr_t> const crd{ 20, 50, 30, 40, 70, 10, 60, 80, 90 };
 
-    // the first CSR "tensor"
+    // a second 3 x 100 CSR array that should overlap at coordinates:
+    // (0, 20), (2, 10), (2, 60), (2, 80)
+    std::vector<uintptr_t> const pos2{ 0, 4, 4, 9 };
+    std::vector<uintptr_t> const crd2{ 20, 22, 30, 50, 5, 10, 60, 80, 99 };
+
     xsparse::levels::dense<std::tuple<>, uintptr_t, uintptr_t> d1{ SIZE1 };
     xsparse::levels::compressed<std::tuple<decltype(d1)>,
                                 uintptr_t,
                                 uintptr_t,
                                 xsparse::util::container_traits<std::vector, std::set, std::map>,
-                                xsparse::level_properties<true, false, false, false, true>>
+                                xsparse::level_properties<true, true, false, false, true>>
         s1{ SIZE2, pos, crd };
-
-    // the second CSR "tensor"
     xsparse::levels::dense<std::tuple<>, uintptr_t, uintptr_t> d2{ SIZE1 };
     xsparse::levels::compressed<std::tuple<decltype(d2)>,
                                 uintptr_t,
                                 uintptr_t,
                                 xsparse::util::container_traits<std::vector, std::set, std::map>,
-                                xsparse::level_properties<true, false, false, false, true>>
+                                xsparse::level_properties<true, true, false, false, true>>
         s2{ SIZE2, pos, crd };
 
     // define a conjunctive function
     auto fn = [](std::tuple<bool, bool> t) constexpr { return (std::get<0>(t) && std::get<1>(t)); };
 
-    // define two coiteration objects that coiterate over the dense and compressed levels respectively
+    // define two coiteration objects that coiterate over the dense and compressed levels
+    // respectively
     xsparse::level_capabilities::Coiterate<
-        xsparse::util::LambdaWrapper<decltype(fn)>::template apply,
-        decltype(fn),
-        uintptr_t,
-        uintptr_t,
-        std::tuple<decltype(s1), decltype(s2)>,
-        std::tuple<>,
-        std::tuple<>>
-        coiter_compressed(fn, s1, s2);
-     xsparse::level_capabilities::Coiterate<
         xsparse::util::LambdaWrapper<decltype(fn)>::template apply,
         decltype(fn),
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(d1), decltype(d2)>,
         std::tuple<>,
-        std::tuple<>>
+        std::tuple<uintptr_t, uintptr_t>>
         coiter_dense(fn, d1, d2);
+
+    xsparse::level_capabilities::Coiterate<
+        xsparse::util::LambdaWrapper<decltype(fn)>::template apply,
+        decltype(fn),
+        uintptr_t,
+        uintptr_t,
+        std::tuple<decltype(s1), decltype(s2)>,
+        std::tuple<uintptr_t>,
+        std::tuple<std::optional<uintptr_t>, std::optional<uintptr_t>>>
+        coiter_compressed(fn, s1, s2);
 
     auto it_helper1 = d1.iter_helper(std::make_tuple(), ZERO);
     auto it1 = it_helper1.begin();
@@ -366,9 +377,10 @@ TEST_CASE("Coiteration-Nested-Levels")
 
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
-    for (auto const [ik, pk_tuple] : coiter_dense.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
+    for (auto const [ik, pk_tuple] :
+         coiter_dense.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
     {
-         // get the index and pointer from the outer-most level involved in co-iteration
+        // get the index and pointer from the outer-most level involved in co-iteration
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
 
@@ -387,7 +399,8 @@ TEST_CASE("Coiteration-Nested-Levels")
         auto end2_inner = it_helper_inner2.end();
 
         // co-iterate over the inner-most compressed level now
-        for (auto const [cik, cpk_tuple] : coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
+        for (auto const [cik, cpk_tuple] :
+             coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
         {
             auto [ci1, cp1] = *it1_inner;
             auto [ci2, cp2] = *it2_inner;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -21,6 +21,8 @@
 #include <xsparse/util/template_utils.hpp>
 
 
+#include <iostream>
+
 TEST_CASE("Coiteration-Dense-Dense")
 {
     constexpr uint8_t ZERO = 0;
@@ -401,8 +403,8 @@ TEST_CASE("Coiteration-Nested-Levels")
         auto it_helper_inner2 = s2.iter_helper(ik, pk2);
         auto it1_inner = it_helper_inner1.begin();
         auto it2_inner = it_helper_inner2.begin();
-        // auto end1_inner = it_helper_inner1.end();
-        // auto end2_inner = it_helper_inner2.end();
+        auto end1_inner = it_helper_inner1.end();
+        auto end2_inner = it_helper_inner2.end();
 
         // co-iterate over the inner-most compressed level now
         for (auto const [cik, cpk_tuple] :
@@ -410,24 +412,26 @@ TEST_CASE("Coiteration-Nested-Levels")
         {
             auto [ci1, cp1] = *it1_inner;
             auto [ci2, cp2] = *it2_inner;
-            uintptr_t l = std::min(ci1, ci2);
 
-            if (ci1 == l)
+            if (ci1 == cik)
             {
                 CHECK(cp1 == std::get<0>(cpk_tuple).value());
                 ++it1_inner;
             }
-            else
+            else if (ci2 == cik)
             {
                 CHECK(cp2 == std::get<1>(cpk_tuple).value());
                 ++it2_inner;
             }
+            else
+            {
+                throw std::runtime_error("CI1 and CI2 does not equal CIK");
+            }
         }
 
         // XOR: only one iterators should have reached the end, but not both and not neither
-        // bool result = (it1_inner == end1_inner) ^ (it2_inner == end2_inner);
-        // CHECK(result);
-        // CHECK(!(it1_inner == end1_inner) && (it2_inner == end2_inner));
+        bool result = (it1_inner == end1_inner) ^ (it2_inner == end2_inner);
+        CHECK(result);
 
         // increment both dense iterators
         ++it1;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -406,7 +406,7 @@ TEST_CASE("Coiteration-Nested-Levels")
         // This is shown below.
 
         // Function to extract value from optional or use default
-        auto extractOrDefault = [](const std::optional<int>& value, int defaultValue)
+        auto extractOrDefault = [](const std::optional<uintptr_t>& value, uintptr_t defaultValue)
         { return value.value_or(defaultValue); };
 
         // Unpack the tuple dynamically using std::apply and lambda

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -21,8 +21,6 @@
 #include <xsparse/util/template_utils.hpp>
 
 
-#include <iostream>
-
 TEST_CASE("Coiteration-Dense-Dense")
 {
     constexpr uint8_t ZERO = 0;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -391,32 +391,35 @@ TEST_CASE("Coiteration-Nested-Levels")
         CHECK(std::get<1>(pk_tuple).value() == p2);
 
         // use these to define the inner-most iterator
-        // auto it_helper_inner1 = s1.iter_helper(i1, p1);
-        // auto it_helper_inner2 = s2.iter_helper(i2, p2);
-        // auto it1_inner = it_helper_inner1.begin();
-        // auto it2_inner = it_helper_inner2.begin();
-        // auto end1_inner = it_helper_inner1.end();
-        // auto end2_inner = it_helper_inner2.end();
+        auto it_helper_inner1 = s1.iter_helper(i1, p1);
+        auto it_helper_inner2 = s2.iter_helper(i2, p2);
+        auto it1_inner = it_helper_inner1.begin();
+        auto it2_inner = it_helper_inner2.begin();
+        auto end1_inner = it_helper_inner1.end();
+        auto end2_inner = it_helper_inner2.end();
 
         // co-iterate over the inner-most compressed level now
-        // for (auto const [cik, cpk_tuple] :
-        //      coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
-        // {
-        //     auto [ci1, cp1] = *it1_inner;
-        //     auto [ci2, cp2] = *it2_inner;
-        //     uintptr_t l = std::min(ci1, ci2);
+        for (auto const [cik, cpk_tuple] :
+             coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
+        {
+            auto [ci1, cp1] = *it1_inner;
+            auto [ci2, cp2] = *it2_inner;
+            uintptr_t l = std::min(ci1, ci2);
 
-        //     if (ci1 == l)
-        //     {
-        //         CHECK(cp1 == std::get<0>(cpk_tuple).value());
-        //         ++it1_inner;
-        //     }
-        //     if (ci2 == l)
-        //     {
-        //         CHECK(cp2 == std::get<1>(cpk_tuple).value());
-        //         ++it2_inner;
-        //     }
-        // }
+            if (ci1 == l)
+            {
+                CHECK(cp1 == std::get<0>(cpk_tuple).value());
+                ++it1_inner;
+            }
+            if (ci2 == l)
+            {
+                CHECK(cp2 == std::get<1>(cpk_tuple).value());
+                ++it2_inner;
+            }
+        }
+
+        // XOR: only one iterators should have reached the end, but not both and not neither
+        CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
 
         // increment both dense iterators
         ++it1;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Coiteration-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2)>,
-        std::tuple<std::tuple<>>,
+        std::tuple<>,
         std::tuple<uintptr_t, uintptr_t>>
         coiter(fn, s1, s2);
 
@@ -49,7 +49,7 @@ TEST_CASE("Coiteration-Dense-Dense")
     auto end2 = it_helper2.end();
 
     for (auto const [ik, pk_tuple] :
-         coiter.coiter_helper(std::make_tuple(std::make_tuple()), std::make_tuple(ZERO, ZERO)))
+         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
     {
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
@@ -86,7 +86,7 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3)>,
-        std::tuple<std::tuple<>>,
+        std::tuple<>,
         std::tuple<uintptr_t, uintptr_t, uintptr_t>>
         coiter(fn, s1, s2, s3);
 
@@ -101,7 +101,7 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
     auto end2 = it_helper2.end();
     auto end3 = it_helper3.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(std::make_tuple()),
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(),
                                                           std::make_tuple(ZERO, ZERO, ZERO)))
     {
         auto [i1, p1] = *it1;
@@ -150,7 +150,7 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3), decltype(s4)>,
-        std::tuple<std::tuple<>>,
+        std::tuple<>,
         std::tuple<uintptr_t, uintptr_t, uintptr_t, uintptr_t>>
         coiter(fn, s1, s2, s3, s4);
 
@@ -168,7 +168,7 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
     auto end3 = it_helper3.end();
     auto end4 = it_helper4.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(std::make_tuple()),
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(),
                                                           std::make_tuple(ZERO, ZERO, ZERO, ZERO)))
     {
         if (it1 != end1 && it2 != end2 && it3 != end3 && it4 != end4)
@@ -256,7 +256,7 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(dense_level), decltype(hash_level)>,
-        std::tuple<std::tuple<>>,
+        std::tuple<>,
         std::tuple<uintptr_t, uintptr_t>>
         coiter(fn, dense_level, hash_level);
 
@@ -270,7 +270,7 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
     for (auto const [ik, pk_tuple] :
-         coiter.coiter_helper(std::make_tuple(std::make_tuple()), std::make_tuple(ZERO, ZERO)))
+         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
     {
         // get the index and pointer from the levels involved in co-iteration
         auto [i1, p1] = *it1;
@@ -353,7 +353,7 @@ TEST_CASE("Coiteration-Nested-Levels")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(d1), decltype(d2)>,
-        std::tuple<std::tuple<>>,
+        std::tuple<>,
         std::tuple<uintptr_t, uintptr_t>>
         coiter_dense(fn, d1, d2);
 
@@ -363,7 +363,7 @@ TEST_CASE("Coiteration-Nested-Levels")
         uintptr_t,  // IK
         uintptr_t,  // PK
         std::tuple<decltype(s1), decltype(s2)>,
-        std::tuple<std::tuple<uintptr_t>>,  // tuple of Is, which is passed to coiteration_helper
+        std::tuple<uintptr_t>,  // tuple of Is, which is passed to coiteration_helper
         std::tuple<std::optional<uintptr_t>, std::optional<uintptr_t>>>
         coiter_compressed(fn, s1, s2);
 
@@ -377,7 +377,7 @@ TEST_CASE("Coiteration-Nested-Levels")
 
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
-    for (auto const [ik, pk_tuple] : coiter_dense.coiter_helper(std::make_tuple(std::make_tuple()),
+    for (auto const [ik, pk_tuple] : coiter_dense.coiter_helper(std::make_tuple(),
                                                                 std::make_tuple(ZERO, ZERO)))
     {
         // get the index and pointer from the outer-most level involved in co-iteration
@@ -392,35 +392,35 @@ TEST_CASE("Coiteration-Nested-Levels")
 
         // XXX: Currently, the below for loop causes a compiler-crash on my laptop
         // use these to define the inner-most iterator
-        auto it_helper_inner1 = s1.iter_helper(i1, p1);
-        auto it_helper_inner2 = s2.iter_helper(i2, p2);
-        auto it1_inner = it_helper_inner1.begin();
-        auto it2_inner = it_helper_inner2.begin();
-        auto end1_inner = it_helper_inner1.end();
-        auto end2_inner = it_helper_inner2.end();
+        // auto it_helper_inner1 = s1.iter_helper(i1, p1);
+        // auto it_helper_inner2 = s2.iter_helper(i2, p2);
+        // auto it1_inner = it_helper_inner1.begin();
+        // auto it2_inner = it_helper_inner2.begin();
+        // auto end1_inner = it_helper_inner1.end();
+        // auto end2_inner = it_helper_inner2.end();
 
-        // co-iterate over the inner-most compressed level now
-        for (auto const [cik, cpk_tuple] :
-             coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
-        {
-            auto [ci1, cp1] = *it1_inner;
-            auto [ci2, cp2] = *it2_inner;
-            uintptr_t l = std::min(ci1, ci2);
+        // // co-iterate over the inner-most compressed level now
+        // for (auto const [cik, cpk_tuple] :
+        //      coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
+        // {
+        //     auto [ci1, cp1] = *it1_inner;
+        //     auto [ci2, cp2] = *it2_inner;
+        //     uintptr_t l = std::min(ci1, ci2);
 
-            if (ci1 == l)
-            {
-                CHECK(cp1 == std::get<0>(cpk_tuple).value());
-                ++it1_inner;
-            }
-            if (ci2 == l)
-            {
-                CHECK(cp2 == std::get<1>(cpk_tuple).value());
-                ++it2_inner;
-            }
-        }
+        //     if (ci1 == l)
+        //     {
+        //         CHECK(cp1 == std::get<0>(cpk_tuple).value());
+        //         ++it1_inner;
+        //     }
+        //     if (ci2 == l)
+        //     {
+        //         CHECK(cp2 == std::get<1>(cpk_tuple).value());
+        //         ++it2_inner;
+        //     }
+        // }
 
-        // XOR: only one iterators should have reached the end, but not both and not neither
-        CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
+        // // XOR: only one iterators should have reached the end, but not both and not neither
+        // CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
 
         // increment both dense iterators
         ++it1;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -395,8 +395,8 @@ TEST_CASE("Coiteration-Nested-Levels")
         auto it_helper_inner2 = s2.iter_helper(i2, p2);
         auto it1_inner = it_helper_inner1.begin();
         auto it2_inner = it_helper_inner2.begin();
-        auto end1_inner = it_helper_inner1.end();
-        auto end2_inner = it_helper_inner2.end();
+        // auto end1_inner = it_helper_inner1.end();
+        // auto end2_inner = it_helper_inner2.end();
 
         // co-iterate over the inner-most compressed level now
         for (auto const [cik, cpk_tuple] :

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -392,35 +392,35 @@ TEST_CASE("Coiteration-Nested-Levels")
 
         // XXX: Currently, the below for loop causes a compiler-crash on my laptop
         // use these to define the inner-most iterator
-        // auto it_helper_inner1 = s1.iter_helper(i1, p1);
-        // auto it_helper_inner2 = s2.iter_helper(i2, p2);
-        // auto it1_inner = it_helper_inner1.begin();
-        // auto it2_inner = it_helper_inner2.begin();
-        // auto end1_inner = it_helper_inner1.end();
-        // auto end2_inner = it_helper_inner2.end();
+        auto it_helper_inner1 = s1.iter_helper(i1, p1);
+        auto it_helper_inner2 = s2.iter_helper(i2, p2);
+        auto it1_inner = it_helper_inner1.begin();
+        auto it2_inner = it_helper_inner2.begin();
+        auto end1_inner = it_helper_inner1.end();
+        auto end2_inner = it_helper_inner2.end();
 
-        // // co-iterate over the inner-most compressed level now
-        // for (auto const [cik, cpk_tuple] :
-        //      coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
-        // {
-        //     auto [ci1, cp1] = *it1_inner;
-        //     auto [ci2, cp2] = *it2_inner;
-        //     uintptr_t l = std::min(ci1, ci2);
+        // co-iterate over the inner-most compressed level now
+        for (auto const [cik, cpk_tuple] :
+             coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
+        {
+            auto [ci1, cp1] = *it1_inner;
+            auto [ci2, cp2] = *it2_inner;
+            uintptr_t l = std::min(ci1, ci2);
 
-        //     if (ci1 == l)
-        //     {
-        //         CHECK(cp1 == std::get<0>(cpk_tuple).value());
-        //         ++it1_inner;
-        //     }
-        //     if (ci2 == l)
-        //     {
-        //         CHECK(cp2 == std::get<1>(cpk_tuple).value());
-        //         ++it2_inner;
-        //     }
-        // }
+            if (ci1 == l)
+            {
+                CHECK(cp1 == std::get<0>(cpk_tuple).value());
+                ++it1_inner;
+            }
+            if (ci2 == l)
+            {
+                CHECK(cp2 == std::get<1>(cpk_tuple).value());
+                ++it2_inner;
+            }
+        }
 
-        // // XOR: only one iterators should have reached the end, but not both and not neither
-        // CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
+        // XOR: only one iterators should have reached the end, but not both and not neither
+        CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
 
         // increment both dense iterators
         ++it1;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Coiteration-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2)>,
-        std::tuple<>,
+        std::tuple<std::tuple<>>,
         std::tuple<uintptr_t, uintptr_t>>
         coiter(fn, s1, s2);
 
@@ -49,7 +49,7 @@ TEST_CASE("Coiteration-Dense-Dense")
     auto end2 = it_helper2.end();
 
     for (auto const [ik, pk_tuple] :
-         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
+         coiter.coiter_helper(std::make_tuple(std::make_tuple()), std::make_tuple(ZERO, ZERO)))
     {
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
@@ -86,7 +86,7 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3)>,
-        std::tuple<>,
+        std::tuple<std::tuple<>>,
         std::tuple<uintptr_t, uintptr_t, uintptr_t>>
         coiter(fn, s1, s2, s3);
 
@@ -101,8 +101,8 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
     auto end2 = it_helper2.end();
     auto end3 = it_helper3.end();
 
-    for (auto const [ik, pk_tuple] :
-         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO, ZERO)))
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(std::make_tuple()),
+                                                          std::make_tuple(ZERO, ZERO, ZERO)))
     {
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
@@ -150,7 +150,7 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3), decltype(s4)>,
-        std::tuple<>,
+        std::tuple<std::tuple<>>,
         std::tuple<uintptr_t, uintptr_t, uintptr_t, uintptr_t>>
         coiter(fn, s1, s2, s3, s4);
 
@@ -168,8 +168,8 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
     auto end3 = it_helper3.end();
     auto end4 = it_helper4.end();
 
-    for (auto const [ik, pk_tuple] :
-         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO, ZERO, ZERO)))
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(std::make_tuple()),
+                                                          std::make_tuple(ZERO, ZERO, ZERO, ZERO)))
     {
         if (it1 != end1 && it2 != end2 && it3 != end3 && it4 != end4)
         {
@@ -256,7 +256,7 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(dense_level), decltype(hash_level)>,
-        std::tuple<>,
+        std::tuple<std::tuple<>>,
         std::tuple<uintptr_t, uintptr_t>>
         coiter(fn, dense_level, hash_level);
 
@@ -270,7 +270,7 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
     for (auto const [ik, pk_tuple] :
-         coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
+         coiter.coiter_helper(std::make_tuple(std::make_tuple()), std::make_tuple(ZERO, ZERO)))
     {
         // get the index and pointer from the levels involved in co-iteration
         auto [i1, p1] = *it1;
@@ -353,17 +353,17 @@ TEST_CASE("Coiteration-Nested-Levels")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(d1), decltype(d2)>,
-        std::tuple<>,
+        std::tuple<std::tuple<>>,
         std::tuple<uintptr_t, uintptr_t>>
         coiter_dense(fn, d1, d2);
 
     xsparse::level_capabilities::Coiterate<
         xsparse::util::LambdaWrapper<decltype(fn)>::template apply,
         decltype(fn),
-        uintptr_t,
-        uintptr_t,
+        uintptr_t,  // IK
+        uintptr_t,  // PK
         std::tuple<decltype(s1), decltype(s2)>,
-        std::tuple<uintptr_t>,
+        std::tuple<std::tuple<uintptr_t>>,  // tuple of Is, which is passed to coiteration_helper
         std::tuple<std::optional<uintptr_t>, std::optional<uintptr_t>>>
         coiter_compressed(fn, s1, s2);
 
@@ -377,8 +377,8 @@ TEST_CASE("Coiteration-Nested-Levels")
 
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
-    for (auto const [ik, pk_tuple] :
-         coiter_dense.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
+    for (auto const [ik, pk_tuple] : coiter_dense.coiter_helper(std::make_tuple(std::make_tuple()),
+                                                                std::make_tuple(ZERO, ZERO)))
     {
         // get the index and pointer from the outer-most level involved in co-iteration
         auto [i1, p1] = *it1;
@@ -391,32 +391,32 @@ TEST_CASE("Coiteration-Nested-Levels")
         CHECK(std::get<1>(pk_tuple).value() == p2);
 
         // use these to define the inner-most iterator
-        auto it_helper_inner1 = s1.iter_helper(i1, p1);
-        auto it_helper_inner2 = s2.iter_helper(i2, p2);
-        auto it1_inner = it_helper_inner1.begin();
-        auto it2_inner = it_helper_inner2.begin();
+        // auto it_helper_inner1 = s1.iter_helper(i1, p1);
+        // auto it_helper_inner2 = s2.iter_helper(i2, p2);
+        // auto it1_inner = it_helper_inner1.begin();
+        // auto it2_inner = it_helper_inner2.begin();
         // auto end1_inner = it_helper_inner1.end();
         // auto end2_inner = it_helper_inner2.end();
 
         // co-iterate over the inner-most compressed level now
-        for (auto const [cik, cpk_tuple] :
-             coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
-        {
-            auto [ci1, cp1] = *it1_inner;
-            auto [ci2, cp2] = *it2_inner;
-            uintptr_t l = std::min(ci1, ci2);
+        // for (auto const [cik, cpk_tuple] :
+        //      coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
+        // {
+        //     auto [ci1, cp1] = *it1_inner;
+        //     auto [ci2, cp2] = *it2_inner;
+        //     uintptr_t l = std::min(ci1, ci2);
 
-            if (ci1 == l)
-            {
-                CHECK(cp1 == std::get<0>(cpk_tuple).value());
-                ++it1_inner;
-            }
-            if (ci2 == l)
-            {
-                CHECK(cp2 == std::get<1>(cpk_tuple).value());
-                ++it2_inner;
-            }
-        }
+        //     if (ci1 == l)
+        //     {
+        //         CHECK(cp1 == std::get<0>(cpk_tuple).value());
+        //         ++it1_inner;
+        //     }
+        //     if (ci2 == l)
+        //     {
+        //         CHECK(cp2 == std::get<1>(cpk_tuple).value());
+        //         ++it2_inner;
+        //     }
+        // }
 
         // increment both dense iterators
         ++it1;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -366,7 +366,7 @@ TEST_CASE("Coiteration-Nested-Levels")
 
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
-    for (auto const [ik, pk_tuple] : coiter_dense.coiter_helper(std::make_tuple(), std::make_tuple()))
+    for (auto const [ik, pk_tuple] : coiter_dense.coiter_helper(std::make_tuple(), std::make_tuple(ZERO, ZERO)))
     {
          // get the index and pointer from the outer-most level involved in co-iteration
         auto [i1, p1] = *it1;
@@ -387,7 +387,7 @@ TEST_CASE("Coiteration-Nested-Levels")
         auto end2_inner = it_helper_inner2.end();
 
         // co-iterate over the inner-most compressed level now
-        for (auto const [cik, cpk_tuple] : coiter_compressed.coiter_helper(std::make_tuple(ik, ik), pk_tuple))
+        for (auto const [cik, cpk_tuple] : coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
         {
             auto [ci1, cp1] = *it1_inner;
             auto [ci2, cp2] = *it2_inner;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -390,36 +390,37 @@ TEST_CASE("Coiteration-Nested-Levels")
         CHECK(std::get<0>(pk_tuple).value() == p1);
         CHECK(std::get<1>(pk_tuple).value() == p2);
 
+        // XXX: Currently, the below for loop causes a compiler-crash on my laptop
         // use these to define the inner-most iterator
-        auto it_helper_inner1 = s1.iter_helper(i1, p1);
-        auto it_helper_inner2 = s2.iter_helper(i2, p2);
-        auto it1_inner = it_helper_inner1.begin();
-        auto it2_inner = it_helper_inner2.begin();
-        auto end1_inner = it_helper_inner1.end();
-        auto end2_inner = it_helper_inner2.end();
+        // auto it_helper_inner1 = s1.iter_helper(i1, p1);
+        // auto it_helper_inner2 = s2.iter_helper(i2, p2);
+        // auto it1_inner = it_helper_inner1.begin();
+        // auto it2_inner = it_helper_inner2.begin();
+        // auto end1_inner = it_helper_inner1.end();
+        // auto end2_inner = it_helper_inner2.end();
 
-        // co-iterate over the inner-most compressed level now
-        for (auto const [cik, cpk_tuple] :
-             coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
-        {
-            auto [ci1, cp1] = *it1_inner;
-            auto [ci2, cp2] = *it2_inner;
-            uintptr_t l = std::min(ci1, ci2);
+        // // co-iterate over the inner-most compressed level now
+        // for (auto const [cik, cpk_tuple] :
+        //      coiter_compressed.coiter_helper(std::make_tuple(std::make_tuple(ik)), pk_tuple))
+        // {
+        //     auto [ci1, cp1] = *it1_inner;
+        //     auto [ci2, cp2] = *it2_inner;
+        //     uintptr_t l = std::min(ci1, ci2);
 
-            if (ci1 == l)
-            {
-                CHECK(cp1 == std::get<0>(cpk_tuple).value());
-                ++it1_inner;
-            }
-            if (ci2 == l)
-            {
-                CHECK(cp2 == std::get<1>(cpk_tuple).value());
-                ++it2_inner;
-            }
-        }
+        //     if (ci1 == l)
+        //     {
+        //         CHECK(cp1 == std::get<0>(cpk_tuple).value());
+        //         ++it1_inner;
+        //     }
+        //     if (ci2 == l)
+        //     {
+        //         CHECK(cp2 == std::get<1>(cpk_tuple).value());
+        //         ++it2_inner;
+        //     }
+        // }
 
-        // XOR: only one iterators should have reached the end, but not both and not neither
-        CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
+        // // XOR: only one iterators should have reached the end, but not both and not neither
+        // CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
 
         // increment both dense iterators
         ++it1;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -368,9 +368,46 @@ TEST_CASE("Coiteration-Nested-Levels")
     // check if the index exists in the hashed level. If not, then we skip it.
     for (auto const [ik, pk_tuple] : coiter_dense.coiter_helper(std::make_tuple(), std::make_tuple()))
     {
-        for (auto const [cik, cpk_tuple] : coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
+         // get the index and pointer from the outer-most level involved in co-iteration
+        auto [i1, p1] = *it1;
+        auto [i2, p2] = *it2;
+
+        // the index should be the same for both levels and tracked via the co-iterator
+        CHECK(ik == i1);
+        CHECK(ik == i2);
+        CHECK(std::get<0>(pk_tuple).value() == p1);
+        CHECK(std::get<1>(pk_tuple).value() == p2);
+
+        // use these to define the inner-most iterator
+        auto it_helper_inner1 = s1.iter_helper(i1, p1);
+        auto it_helper_inner2 = s2.iter_helper(i2, p2);
+        auto it1_inner = it_helper_inner1.begin();
+        auto it2_inner = it_helper_inner2.begin();
+        auto end1_inner = it_helper_inner1.end();
+        auto end2_inner = it_helper_inner2.end();
+
+        // co-iterate over the inner-most compressed level now
+        for (auto const [cik, cpk_tuple] : coiter_compressed.coiter_helper(std::make_tuple(ik, ik), pk_tuple))
         {
+            auto [ci1, cp1] = *it1_inner;
+            auto [ci2, cp2] = *it2_inner;
+            uintptr_t l = std::min(ci1, ci2);
+
+            if (ci1 == l)
+            {
+                CHECK(cp1 == std::get<0>(cpk_tuple).value());
+                ++it1_inner;
+            }
+            if (ci2 == l)
+            {
+                CHECK(cp2 == std::get<1>(cpk_tuple).value());
+                ++it2_inner;
+            }
         }
+
+        // increment both dense iterators
+        ++it1;
+        ++it2;
     }
 
     // check that the dense levelS should've reached its end

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -34,6 +34,7 @@ TEST_CASE("Coiteration-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2)>,
+        std::tuple<>,
         std::tuple<>>
         coiter(fn, s1, s2);
 
@@ -45,7 +46,7 @@ TEST_CASE("Coiteration-Dense-Dense")
     auto end1 = it_helper1.end();
     auto end2 = it_helper2.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), ZERO))
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO)))
     {
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
@@ -82,6 +83,7 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3)>,
+        std::tuple<>,
         std::tuple<>>
         coiter(fn, s1, s2, s3);
 
@@ -96,7 +98,7 @@ TEST_CASE("Coiteration-Dense-Dense-Dense")
     auto end2 = it_helper2.end();
     auto end3 = it_helper3.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), ZERO))
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO)))
     {
         auto [i1, p1] = *it1;
         auto [i2, p2] = *it2;
@@ -144,6 +146,7 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(s1), decltype(s2), decltype(s3), decltype(s4)>,
+        std::tuple<>,
         std::tuple<>>
         coiter(fn, s1, s2, s3, s4);
 
@@ -161,7 +164,7 @@ TEST_CASE("Coiteration-Singleton-Singleton-Dense-Dense")
     auto end3 = it_helper3.end();
     auto end4 = it_helper4.end();
 
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), ZERO))
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO)))
     {
         if (it1 != end1 && it2 != end2 && it3 != end3 && it4 != end4)
         {
@@ -248,6 +251,7 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
         uintptr_t,
         uintptr_t,
         std::tuple<decltype(dense_level), decltype(hash_level)>,
+        std::tuple<>,
         std::tuple<>>
         coiter(fn, dense_level, hash_level);
 
@@ -260,7 +264,7 @@ TEST_CASE("Coiteration-Dense-Hashed-ConjunctiveMerge")
 
     // when co-iterating over levels that are unordered (i.e. hashed), then we use locate to
     // check if the index exists in the hashed level. If not, then we skip it.
-    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), ZERO))
+    for (auto const [ik, pk_tuple] : coiter.coiter_helper(std::make_tuple(), std::make_tuple(ZERO)))
     {
         // get the index and pointer from the levels involved in co-iteration
         auto [i1, p1] = *it1;

--- a/test/source/coiteration_test.cpp
+++ b/test/source/coiteration_test.cpp
@@ -392,35 +392,35 @@ TEST_CASE("Coiteration-Nested-Levels")
 
         // XXX: Currently, the below for loop causes a compiler-crash on my laptop
         // use these to define the inner-most iterator
-        // auto it_helper_inner1 = s1.iter_helper(i1, p1);
-        // auto it_helper_inner2 = s2.iter_helper(i2, p2);
-        // auto it1_inner = it_helper_inner1.begin();
-        // auto it2_inner = it_helper_inner2.begin();
-        // auto end1_inner = it_helper_inner1.end();
-        // auto end2_inner = it_helper_inner2.end();
+        auto it_helper_inner1 = s1.iter_helper(i1, p1);
+        auto it_helper_inner2 = s2.iter_helper(i2, p2);
+        auto it1_inner = it_helper_inner1.begin();
+        auto it2_inner = it_helper_inner2.begin();
+        auto end1_inner = it_helper_inner1.end();
+        auto end2_inner = it_helper_inner2.end();
 
-        // // co-iterate over the inner-most compressed level now
-        // for (auto const [cik, cpk_tuple] :
-        //      coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
-        // {
-        //     auto [ci1, cp1] = *it1_inner;
-        //     auto [ci2, cp2] = *it2_inner;
-        //     uintptr_t l = std::min(ci1, ci2);
+        // co-iterate over the inner-most compressed level now
+        for (auto const [cik, cpk_tuple] :
+             coiter_compressed.coiter_helper(std::make_tuple(ik), pk_tuple))
+        {
+            auto [ci1, cp1] = *it1_inner;
+            auto [ci2, cp2] = *it2_inner;
+            uintptr_t l = std::min(ci1, ci2);
 
-        //     if (ci1 == l)
-        //     {
-        //         CHECK(cp1 == std::get<0>(cpk_tuple).value());
-        //         ++it1_inner;
-        //     }
-        //     if (ci2 == l)
-        //     {
-        //         CHECK(cp2 == std::get<1>(cpk_tuple).value());
-        //         ++it2_inner;
-        //     }
-        // }
+            if (ci1 == l)
+            {
+                CHECK(cp1 == std::get<0>(cpk_tuple).value());
+                ++it1_inner;
+            }
+            if (ci2 == l)
+            {
+                CHECK(cp2 == std::get<1>(cpk_tuple).value());
+                ++it2_inner;
+            }
+        }
 
-        // // XOR: only one iterators should have reached the end, but not both and not neither
-        // CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
+        // XOR: only one iterators should have reached the end, but not both and not neither
+        CHECK(!(it1_inner == end1_inner) != !(it2_inner == end2_inner));
 
         // increment both dense iterators
         ++it1;


### PR DESCRIPTION
The current coiteration algorithm works when we define levels that are not stacked. Therefore, when we initialize `coiter_helper`, we just pass in an empty tuple and a `ZERO` marker for the IKs and PK. 

This is fine and works now, but it will not work when we want to use coiteration on levels that are nested in other levels. For example, say we have a dense pointing to a compressed level. Then we need to pass in the IK and PK of the dense, so we know where to start iterating in the compressed level. This is not currently supported because there is only one PK that is passed in. We need to pass in a tuple of PKs and tuple of IKs, not just a tuple of IKs and a PK.

### Sketch of plan

1. Define the unit-test that this must pass: Define a set of nested levels. Define two co-iterators.
2. Implement change in `co_iteration.hpp`


### Some difficulties

1. The changing of the PK to a tuple of PKs will change the design of the coiterator. It remains tbd how this will affect everything else